### PR TITLE
feat(vpn): add VPN on/off indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,15 @@ echo "Execution time: ${duration}ms"
 bun run build
 # or npm run build
 
+# Build the bundled version (required after code changes)
+# The bin wrapper prefers index.bundle.js over index.js
+bun run build:bundle
+# or npm run build:bundle
+
+# Build both (TypeScript + bundle) - use this after making changes
+bun run build && bun run build:bundle
+# or npm run build && npm run build:bundle
+
 # Run with Bun debugging
 bun --inspect dist/index.bundle.js
 # or node --inspect dist/index.bundle.js

--- a/bin/claude-statusline
+++ b/bin/claude-statusline
@@ -7,26 +7,10 @@
 
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { readlinkSync } from 'fs';
+import { realpathSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
-let __dirname = dirname(__filename);
-
-// Resolve symlinks to get the real project root directory
-try {
-  // If this file is a symlink, resolve it to get the real path
-  const realPath = readlinkSync(__filename);
-  if (realPath) {
-    // The symlink points to the actual file, so we need to go up one level from the bin directory
-    __dirname = join(dirname(realPath), '..');
-  }
-} catch (err) {
-  // Not a symlink or readlink failed, use relative path from bin/
-  // Check if we're in bin/ directory
-  if (__dirname.endsWith('/bin') || __dirname.endsWith('\\bin')) {
-    __dirname = join(__dirname, '..');
-  }
-}
+const __dirname = join(dirname(realpathSync(__filename)), '..');
 
 // Import the main module (prefer bundled version if it exists)
 try {

--- a/bin/claude-statusline
+++ b/bin/claude-statusline
@@ -7,14 +7,31 @@
 
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { readlinkSync } from 'fs';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+let __dirname = dirname(__filename);
+
+// Resolve symlinks to get the real project root directory
+try {
+  // If this file is a symlink, resolve it to get the real path
+  const realPath = readlinkSync(__filename);
+  if (realPath) {
+    // The symlink points to the actual file, so we need to go up one level from the bin directory
+    __dirname = join(dirname(realPath), '..');
+  }
+} catch (err) {
+  // Not a symlink or readlink failed, use relative path from bin/
+  // Check if we're in bin/ directory
+  if (__dirname.endsWith('/bin') || __dirname.endsWith('\\bin')) {
+    __dirname = join(__dirname, '..');
+  }
+}
 
 // Import the main module (prefer bundled version if it exists)
 try {
-  const { main } = await import(join(__dirname, '..', 'dist', 'index.bundle.js'))
-    .catch(() => import(join(__dirname, '..', 'dist', 'index.js')));
+  const { main } = await import(join(__dirname, 'dist', 'index.bundle.js'))
+    .catch(() => import(join(__dirname, 'dist', 'index.js')));
   await main();
 } catch (error) {
   console.error('[ERROR] Failed to load claude-statusline:', error instanceof Error ? error.message : String(error));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-statusline",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Simple statusline for Claude Code with git indicators. TypeScript rewrite for performance and npm distribution.",
   "main": "dist/index.bundle.js",
   "bin": {

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -218,6 +218,7 @@ export const CacheKeys = {
   PYTHON_VERSION: 'python_version',
   PYTHON3_VERSION: 'python3_version',
   DOCKER_VERSION: 'docker_version',
+  VPN_STATUS: 'vpn_status',
   GIT_REMOTE_URL: (dir: string) => `git_remote_${Buffer.from(dir).toString('base64')}`,
   GIT_BRANCH: (dir: string) => `git_branch_${Buffer.from(dir).toString('base64')}`,
 } as const;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -58,8 +58,8 @@ export const ConfigSchema = z.object({
     diverged: z.string().default('D'),
     renamed: z.string().default('>'),
     deleted: z.string().default('X'),
-    vpnOn: z.string().default('◉'),
-    vpnOff: z.string().default('○'),
+    vpnOn: z.string().default('✓·vpn ·'),
+    vpnOff: z.string().default('✗·vpn ·'),
   }).default({}),
 });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -18,6 +18,7 @@ export const ConfigSchema = z.object({
   noGitStatus: z.boolean().default(false), // Disable git indicators
   noContextWindow: z.boolean().default(false), // Disable context window usage
   envContext: z.boolean().default(false), // Show environment versions
+  vpnIndicator: z.boolean().default(false), // Show VPN status indicator (macOS only)
   truncate: z.boolean().default(false), // Smart truncation
   softWrap: z.boolean().default(false), // Soft wrapping (legacy)
   noSoftWrap: z.boolean().default(false), // Disable soft-wrapping
@@ -40,6 +41,8 @@ export const ConfigSchema = z.object({
     diverged: z.string().default('⇕'),
     renamed: z.string().default('»'),
     deleted: z.string().default('✘'),
+    vpnOn: z.string().default('◉'),
+    vpnOff: z.string().default('○'),
   }).default({}),
 
   // ASCII fallback symbols
@@ -55,6 +58,8 @@ export const ConfigSchema = z.object({
     diverged: z.string().default('D'),
     renamed: z.string().default('>'),
     deleted: z.string().default('X'),
+    vpnOn: z.string().default('◉'),
+    vpnOff: z.string().default('○'),
   }).default({}),
 });
 
@@ -143,6 +148,10 @@ function loadEnvConfig(): Partial<Config> {
     env.envContext = true;
   }
 
+  if (process.env.CLAUDE_CODE_STATUSLINE_VPN_INDICATOR === '1') {
+    env.vpnIndicator = true;
+  }
+
   if (process.env.CLAUDE_CODE_STATUSLINE_TRUNCATE === '1') {
     env.truncate = true;
   }
@@ -199,6 +208,7 @@ export function generateSampleConfig(): string {
     noGitStatus: false, // Set to true to disable git indicators
     noContextWindow: false, // Set to true to disable context window usage
     envContext: true, // Set to true to show Node.js, Python versions
+    vpnIndicator: true, // Set to true to show VPN status indicator (macOS only)
     truncate: true, // Set to true to enable smart truncation
     softWrap: false, // Set to true to enable soft wrapping
 
@@ -219,6 +229,8 @@ export function generateSampleConfig(): string {
       diverged: '⇕',
       renamed: '»',
       deleted: '✘',
+      vpnOn: '◉',
+      vpnOff: '○',
     },
   }, null, 2);
 }

--- a/src/env/context.ts
+++ b/src/env/context.ts
@@ -38,23 +38,25 @@ export class EnvironmentDetector {
 
     const envInfo: EnvironmentInfo = {};
 
-    // Get version information in parallel for better performance
-    const [nodeVersion, pythonVersion, dockerVersion] = await Promise.allSettled([
-      this.getNodeVersion(),
-      this.getPythonVersion(),
-      this.getDockerVersion(),
-    ]);
+    // Only fetch environment versions if envContext is enabled
+    if (this.config.envContext) {
+      const [nodeVersion, pythonVersion, dockerVersion] = await Promise.allSettled([
+        this.getNodeVersion(),
+        this.getPythonVersion(),
+        this.getDockerVersion(),
+      ]);
 
-    if (nodeVersion.status === 'fulfilled' && nodeVersion.value) {
-      envInfo.node = nodeVersion.value;
-    }
+      if (nodeVersion.status === 'fulfilled' && nodeVersion.value) {
+        envInfo.node = nodeVersion.value;
+      }
 
-    if (pythonVersion.status === 'fulfilled' && pythonVersion.value) {
-      envInfo.python = pythonVersion.value;
-    }
+      if (pythonVersion.status === 'fulfilled' && pythonVersion.value) {
+        envInfo.python = pythonVersion.value;
+      }
 
-    if (dockerVersion.status === 'fulfilled' && dockerVersion.value) {
-      envInfo.docker = dockerVersion.value;
+      if (dockerVersion.status === 'fulfilled' && dockerVersion.value) {
+        envInfo.docker = dockerVersion.value;
+      }
     }
 
     // Get VPN status if needed

--- a/src/env/context.ts
+++ b/src/env/context.ts
@@ -9,6 +9,7 @@ export interface EnvironmentInfo {
   node?: string;
   python?: string;
   docker?: string;
+  vpn?: boolean;
 }
 
 /**
@@ -28,7 +29,10 @@ export class EnvironmentDetector {
    * Get environment information if context is enabled
    */
   async getEnvironmentInfo(): Promise<EnvironmentInfo | null> {
-    if (!this.config.envContext) {
+    // Always get VPN status if vpnIndicator is enabled, regardless of envContext
+    const shouldGetVPN = this.config.vpnIndicator || this.config.envContext;
+
+    if (!this.config.envContext && !this.config.vpnIndicator) {
       return null;
     }
 
@@ -53,7 +57,16 @@ export class EnvironmentDetector {
       envInfo.docker = dockerVersion.value;
     }
 
+    // Get VPN status if needed
+    if (shouldGetVPN) {
+      const vpnStatus = await this.getVPNStatus();
+      if (vpnStatus !== null) {
+        envInfo.vpn = vpnStatus;
+      }
+    }
+
     // Return null if no environment versions were found
+    // But still return envInfo if only VPN status is present and vpnIndicator is enabled
     if (Object.keys(envInfo).length === 0) {
       return null;
     }
@@ -182,6 +195,40 @@ export class EnvironmentDetector {
     } catch (error) {
       console.debug('[DEBUG] Failed to get Docker version:', error instanceof Error ? error.message : String(error));
       return null;
+    }
+  }
+
+  /**
+   * Get VPN status with caching (macOS only)
+   * Detects VPN by checking for UTun (User Tunnel) interfaces
+   */
+  private async getVPNStatus(): Promise<boolean | null> {
+    // Only support macOS for now
+    if (process.platform !== 'darwin') {
+      return null;
+    }
+
+    const cacheKey = CacheKeys.VPN_STATUS;
+
+    try {
+      // Use a shorter TTL for VPN status (30 seconds) since it can change frequently
+      const vpnTTL = this.config.cacheTTL / 10;
+
+      // Execute scutil --nwi and grep for utun interfaces (case-insensitive)
+      const result = await cachedCommand(
+        this.cache,
+        cacheKey,
+        'sh',
+        ['-c', 'scutil --nwi 2>/dev/null | grep -qi utun && echo "detected" || echo "not detected"'],
+        vpnTTL
+      );
+
+      // If grep finds utun, the command outputs "detected", otherwise "not detected"
+      return result?.trim() === 'detected';
+
+    } catch (error) {
+      console.debug('[DEBUG] Failed to get VPN status:', error instanceof Error ? error.message : String(error));
+      return false;
     }
   }
 

--- a/src/env/context.ts
+++ b/src/env/context.ts
@@ -30,7 +30,7 @@ export class EnvironmentDetector {
    */
   async getEnvironmentInfo(): Promise<EnvironmentInfo | null> {
     // Always get VPN status if vpnIndicator is enabled, regardless of envContext
-    const shouldGetVPN = this.config.vpnIndicator || this.config.envContext;
+    const shouldGetVPN = this.config.vpnIndicator;
 
     if (!this.config.envContext && !this.config.vpnIndicator) {
       return null;
@@ -230,7 +230,7 @@ export class EnvironmentDetector {
 
     } catch (error) {
       console.debug('[DEBUG] Failed to get VPN status:', error instanceof Error ? error.message : String(error));
-      return false;
+      return null;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,10 @@ async function buildStatusline(params: {
   // Build VPN indicator (shown before project name when enabled)
   let vpnIndicator = '';
   if (config.vpnIndicator && envInfo?.vpn !== undefined) {
-    vpnIndicator = (envInfo.vpn ? symbols.vpnOn : symbols.vpnOff) + ' ';
+    const vpnSymbol = envInfo.vpn ? symbols.vpnOn : symbols.vpnOff;
+    if (vpnSymbol) {
+      vpnIndicator = vpnSymbol + ' ';
+    }
   }
 
   // Build git status string

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,12 @@ async function buildStatusline(params: {
   // Get project name
   const projectName = fullDir.split('/').pop() || fullDir.split('\\').pop() || 'project';
 
+  // Build VPN indicator (shown before project name when enabled)
+  let vpnIndicator = '';
+  if (config.vpnIndicator && envInfo?.vpn !== undefined) {
+    vpnIndicator = envInfo.vpn ? symbols.vpnOn : symbols.vpnOff;
+  }
+
   // Build git status string
   let gitStatus = '';
   if (gitInfo) {
@@ -191,7 +197,7 @@ async function buildStatusline(params: {
   const modelString = `${symbols.model}${modelName}${envContext}${contextUsage}`;
 
   // Initial statusline
-  let statusline = `${projectName}${gitStatus} ${modelString}`;
+  let statusline = `${vpnIndicator}${projectName}${gitStatus} ${modelString}`;
 
   // Apply smart truncation if enabled
   if (config.truncate) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ async function buildStatusline(params: {
   // Build VPN indicator (shown before project name when enabled)
   let vpnIndicator = '';
   if (config.vpnIndicator && envInfo?.vpn !== undefined) {
-    vpnIndicator = envInfo.vpn ? symbols.vpnOn : symbols.vpnOff;
+    vpnIndicator = (envInfo.vpn ? symbols.vpnOn : symbols.vpnOff) + ' ';
   }
 
   // Build git status string

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,10 @@ async function buildStatusline(params: {
   if (envInfo) {
     const envSymbols = getEnvironmentSymbols(symbols);
     const envFormatter = new EnvironmentFormatter(envSymbols);
-    envContext = ` ${envFormatter.formatWithIcons(envInfo)}`;
+    const formattedEnv = envFormatter.formatWithIcons(envInfo);
+    if (formattedEnv) {
+      envContext = ` ${formattedEnv}`;
+    }
   }
 
     // Build context window usage string

--- a/src/ui/symbols.ts
+++ b/src/ui/symbols.ts
@@ -41,8 +41,8 @@ const ASCII_SYMBOLS: SymbolSet = {
   diverged: 'D',
   renamed: '>',
   deleted: 'X',
-  vpnOn: '◉',
-  vpnOff: '○',
+  vpnOn: '✓·vpn ·',
+  vpnOff: '✗·vpn ·',
 };
 
 /**

--- a/src/ui/symbols.ts
+++ b/src/ui/symbols.ts
@@ -22,6 +22,8 @@ export interface SymbolSet {
   diverged: string;
   renamed: string;
   deleted: string;
+  vpnOn: string;
+  vpnOff: string;
 }
 
 /**
@@ -39,6 +41,8 @@ const ASCII_SYMBOLS: SymbolSet = {
   diverged: 'D',
   renamed: '>',
   deleted: 'X',
+  vpnOn: '◉',
+  vpnOff: '○',
 };
 
 /**
@@ -56,6 +60,8 @@ const NERD_FONT_SYMBOLS: SymbolSet = {
   diverged: '⇕',
   renamed: '»',
   deleted: '✘',
+  vpnOn: '◉',
+  vpnOff: '○',
 };
 
 /**


### PR DESCRIPTION
## Summary
- Adds VPN status indicator that displays before the project name
- Shows `◉` when VPN is connected (on) and `○` when disconnected (off)
- macOS-only implementation using `scutil --nwi` to detect `utun` interfaces
- Works independently of environment context setting

## Changes
- Added `vpnIndicator` config option (default: `false`)
- Added `vpnOn` and `vpnOff` symbol options (default: `◉` and `○`)
- Environment variable support: `CLAUDE_CODE_STATUSLINE_VPN_INDICATOR=1`
- VPN status cached with short TTL (30s) since it can change frequently
- Fixed symlink path resolution in bin wrapper for proper module loading
- Fixed extra spacing when envContext is empty

## Example Output
```
◉ claude-statusline  main 󰚩glm-4.7 ⚡︎75%  # VPN on
○ claude-statusline  main 󰚩glm-4.7 ⚡︎75%  # VPN off
```

## Test Plan
- [x] VPN indicator shows when enabled
- [x] Works with symlinked installation (~/.claude/claude-statusline)
- [x] No extra spaces when envContext is disabled
- [x] Proper spacing when envContext is enabled

🤖 Generated by [Claude Code](https://claude.ai/code) - GLM 4.7