### PR TITLE
Phase A: P0 rendering fixes (Tasks A.1–A.4)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,6 +14,7 @@ export const ConfigSchema = z.object({
   maxLength: z.number().default(1000), // Maximum input length
 
   // Feature toggles
+  nerdFont: z.boolean().default(false), // Opt-in Nerd Font glyphs (default: false / ASCII)
   noEmoji: z.boolean().default(false), // Force ASCII mode
   noGitStatus: z.boolean().default(false), // Disable git indicators
   noContextWindow: z.boolean().default(false), // Disable context window usage
@@ -32,7 +33,7 @@ export const ConfigSchema = z.object({
   symbols: z.object({
     git: z.string().default(''),
     model: z.string().default('󰚩'),
-    contextWindow: z.string().default('⚡︎'),
+    contextWindow: z.string().default('⚡'),
     staged: z.string().default('+'),
     conflict: z.string().default('×'),
     stashed: z.string().default('⚑'),
@@ -43,6 +44,9 @@ export const ConfigSchema = z.object({
     deleted: z.string().default('✘'),
     vpnOn: z.string().default('◉'),
     vpnOff: z.string().default('○'),
+    node: z.string().default(''),
+    python: z.string().default(''),
+    docker: z.string().default(''),
   }).default({}),
 
   // ASCII fallback symbols
@@ -60,6 +64,9 @@ export const ConfigSchema = z.object({
     deleted: z.string().default('X'),
     vpnOn: z.string().default('✓·vpn ·'),
     vpnOff: z.string().default('✗·vpn ·'),
+    node: z.string().default('node'),
+    python: z.string().default('py'),
+    docker: z.string().default('dkr'),
   }).default({}),
 });
 
@@ -132,6 +139,10 @@ function loadEnvConfig(): Partial<Config> {
   const env: Partial<Config> = {};
 
   // Feature toggles
+  if (process.env.NERD_FONT === '1' || process.env.CLAUDE_CODE_STATUSLINE_NERD_FONT === '1') {
+    env.nerdFont = true;
+  }
+
   if (process.env.CLAUDE_CODE_STATUSLINE_NO_EMOJI === '1') {
     env.noEmoji = true;
   }
@@ -204,6 +215,7 @@ export function generateSampleConfig(): string {
     maxLength: 1000,
 
     // Feature toggles
+    nerdFont: false, // Set to true to opt-in Nerd Font glyphs
     noEmoji: false, // Set to true to force ASCII mode
     noGitStatus: false, // Set to true to disable git indicators
     noContextWindow: false, // Set to true to disable context window usage
@@ -220,7 +232,7 @@ export function generateSampleConfig(): string {
     symbols: {
       git: '',
       model: '󰚩',
-      contextWindow: '⚡︎',
+      contextWindow: '⚡',
       staged: '+',
       conflict: '×',
       stashed: '⚑',

--- a/src/env/context.ts
+++ b/src/env/context.ts
@@ -430,21 +430,28 @@ export class EnvironmentFormatter {
   }
 
   /**
-   * Format with icons: 22.17 3.13 28.3
+   * Format with icons (Nerd Font): 22.17 3.13 28.3
+   * Format with icons (ASCII): node 22.17 py 3.13 dkr 28.3
    */
   formatWithIcons(envInfo: EnvironmentInfo): string {
     const parts: string[] = [];
 
     if (envInfo.node) {
-      parts.push(`${this.symbols.node}${envInfo.node}`);
+      const icon = this.symbols.node;
+      const sep = /[a-z]/i.test(icon) ? ' ' : '';
+      parts.push(`${icon}${sep}${envInfo.node}`);
     }
 
     if (envInfo.python) {
-      parts.push(`${this.symbols.python}${envInfo.python}`);
+      const icon = this.symbols.python;
+      const sep = /[a-z]/i.test(icon) ? ' ' : '';
+      parts.push(`${icon}${sep}${envInfo.python}`);
     }
 
     if (envInfo.docker) {
-      parts.push(`${this.symbols.docker}${envInfo.docker}`);
+      const icon = this.symbols.docker;
+      const sep = /[a-z]/i.test(icon) ? ' ' : '';
+      parts.push(`${icon}${sep}${envInfo.docker}`);
     }
 
     return parts.join(' ');

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,7 @@ function applySoftWrapToModelString(text: string, maxLength: number): string {
     }
   }
 
-  // If we have context usage (marked by context window icon like ⚡︎ or #)
+  // If we have context usage (marked by context window icon like ⚡ or #)
   // The structure is: [icon][model] [env] [context icon][percentage]
   // We want to prefer keeping: [icon][model] [context icon][percentage] together if possible
 

--- a/src/ui/symbols.ts
+++ b/src/ui/symbols.ts
@@ -1,13 +1,6 @@
 import { Config } from '../core/config.js';
 
 /**
- * Symbol detection cache - symbols don't change during runtime
- * Added cache version to handle potential stale data issues
- */
-const symbolCache = new Map<string, { symbols: SymbolSet; timestamp: number }>();
-const CACHE_VERSION = 1; // Increment to invalidate all caches
-
-/**
  * Symbol configuration interface
  */
 export interface SymbolSet {
@@ -24,10 +17,13 @@ export interface SymbolSet {
   deleted: string;
   vpnOn: string;
   vpnOff: string;
+  node: string;
+  python: string;
+  docker: string;
 }
 
 /**
- * ASCII symbol set (fallback)
+ * ASCII symbol set (default / fallback)
  */
 const ASCII_SYMBOLS: SymbolSet = {
   git: '@',
@@ -43,15 +39,18 @@ const ASCII_SYMBOLS: SymbolSet = {
   deleted: 'X',
   vpnOn: '✓·vpn ·',
   vpnOff: '✗·vpn ·',
+  node: 'node',
+  python: 'py',
+  docker: 'dkr',
 };
 
 /**
- * Nerd Font symbol set (enhanced)
+ * Nerd Font symbol set (opt-in via nerdFont: true)
  */
 const NERD_FONT_SYMBOLS: SymbolSet = {
   git: '',
   model: '󰚩',
-  contextWindow: '⚡︎',
+  contextWindow: '⚡',
   staged: '+',
   conflict: '×',
   stashed: '⚑',
@@ -62,329 +61,37 @@ const NERD_FONT_SYMBOLS: SymbolSet = {
   deleted: '✘',
   vpnOn: '◉',
   vpnOff: '○',
+  node: '',
+  python: '',
+  docker: '',
 };
 
 /**
- * Terminal detection results
- */
-interface TerminalInfo {
-  hasNerdFont: boolean;
-  terminal: string;
-  font: string;
-  method: string;
-}
-
-/**
- * Detect Nerd Font support and return appropriate symbols (with caching)
+ * Detect and return the appropriate symbol set based on config.
+ * Nerd Font is opt-in only — no auto-detection, no filesystem or shell calls.
  */
 export async function detectSymbols(config: Config): Promise<SymbolSet> {
-  // Create cache key based on config and environment
-  const envFingerprint = process.env.NERD_FONT + '|' + process.env.TERM_PROGRAM + '|' + process.env.TERM;
-  const cacheKey = `${CACHE_VERSION}:${config.noEmoji ? 'ascii' : 'nerd'}:${envFingerprint}`;
+  const base = config.nerdFont && !config.noEmoji ? NERD_FONT_SYMBOLS : ASCII_SYMBOLS;
+  const overrides = config.nerdFont && !config.noEmoji ? config.symbols : config.asciiSymbols;
 
-  // Check cache first with timestamp validation
-  const cached = symbolCache.get(cacheKey);
-  if (cached && Date.now() - cached.timestamp < 60000) { // 1 minute cache TTL
-    return cached.symbols;
+  // Merge: base defaults, then user overrides that are non-empty
+  const result = { ...base };
+  for (const [key, val] of Object.entries(overrides)) {
+    if (val !== '') result[key as keyof SymbolSet] = val;
   }
-
-  let symbols: SymbolSet;
-
-  // If emoji/nerd font is explicitly disabled, use ASCII
-  if (config.noEmoji) {
-    symbols = { ...ASCII_SYMBOLS, ...config.symbols, ...config.asciiSymbols };
-  } else {
-    // Try to detect Nerd Font support
-    const detection = await detectNerdFontSupport();
-
-    if (detection.hasNerdFont) {
-      // Merge user's custom symbols with Nerd Font defaults
-      symbols = { ...NERD_FONT_SYMBOLS, ...config.symbols };
-    } else {
-      // Merge user's custom ASCII symbols with ASCII defaults
-      symbols = { ...ASCII_SYMBOLS, ...config.asciiSymbols };
-    }
-  }
-
-  // Cache the result with timestamp
-  symbolCache.set(cacheKey, { symbols, timestamp: Date.now() });
-  return symbols;
+  return result;
 }
 
 /**
- * Comprehensive Nerd Font support detection
+ * Get environment symbols from the resolved symbol set.
+ * No longer hardcodes Nerd Font PUA characters — respects ASCII mode.
  */
-async function detectNerdFontSupport(): Promise<TerminalInfo> {
-  const terminalInfo: TerminalInfo = {
-    hasNerdFont: false,
-    terminal: '',
-    font: '',
-    method: '',
-  };
-
-  // Method 1: Environment variable NERD_FONT=1
-  if (process.env.NERD_FONT === '1') {
-    terminalInfo.hasNerdFont = true;
-    terminalInfo.method = 'NERD_FONT env var';
-    return terminalInfo;
-  }
-
-  // Method 2: Terminal program detection
-  const termProgram = process.env.TERM_PROGRAM;
-  const term = process.env.TERM;
-
-  if (termProgram) {
-    terminalInfo.terminal = termProgram;
-    terminalInfo.method = 'TERM_PROGRAM detection';
-
-    // These terminals commonly have Nerd Font support
-    const nerdFontTerminals = ['vscode', 'ghostty', 'wezterm', 'iterm'];
-    if (nerdFontTerminals.includes(termProgram)) {
-      terminalInfo.hasNerdFont = true;
-      return terminalInfo;
-    }
-  }
-
-  if (term) {
-    terminalInfo.terminal = term;
-    terminalInfo.method = 'TERM detection';
-
-    // These terminal types commonly support Nerd Fonts
-    const nerdFontTerms = ['alacritty', 'kitty', 'wezterm', 'ghostty', 'xterm-256color'];
-    if (nerdFontTerms.includes(term)) {
-      terminalInfo.hasNerdFont = true;
-      return terminalInfo;
-    }
-  }
-
-  // Method 3: Try to detect via font list (Unix/Linux/macOS)
-  const fontDetection = await detectViaFontList();
-  if (fontDetection.hasNerdFont) {
-    terminalInfo.hasNerdFont = true;
-    terminalInfo.font = fontDetection.font;
-    terminalInfo.method = 'font list detection';
-    return terminalInfo;
-  }
-
-  // Method 4: Check for common Nerd Font installation patterns
-  const installDetection = await detectNerdFontInstallation();
-  if (installDetection.hasNerdFont) {
-    terminalInfo.hasNerdFont = true;
-    terminalInfo.font = installDetection.font;
-    terminalInfo.method = 'installation detection';
-    return terminalInfo;
-  }
-
-  // Method 5: Check environment variables that might indicate font support
-  const envDetection = detectFromEnvironment();
-  if (envDetection.hasNerdFont) {
-    terminalInfo.hasNerdFont = true;
-    terminalInfo.method = 'environment detection';
-    return terminalInfo;
-  }
-
-  // Method 6: Platform-specific detection
-  const platformDetection = await detectPlatformSpecific();
-  if (platformDetection.hasNerdFont) {
-    terminalInfo.hasNerdFont = true;
-    terminalInfo.method = 'platform-specific detection';
-    return terminalInfo;
-  }
-
-  // Default: no Nerd Font detected
-  return terminalInfo;
-}
-
-/**
- * Detect Nerd Font via font list command
- */
-async function detectViaFontList(): Promise<{ hasNerdFont: boolean; font: string }> {
-  try {
-    const { exec } = await import('child_process');
-    const { promisify } = await import('util');
-    const execAsync = promisify(exec);
-
-    // Try fc-list (Linux) or system_profiler (macOS)
-    let fontListCommand = '';
-    const platform = process.platform;
-
-    if (platform === 'linux') {
-      fontListCommand = 'fc-list';
-    } else if (platform === 'darwin') {
-      fontListCommand = 'system_profiler SPFontsDataType 2>/dev/null || system_profiler SPFontsDataType';
-    }
-
-    if (fontListCommand) {
-      const { stdout } = await execAsync(fontListCommand, {
-        timeout: 3000,
-        encoding: 'utf-8',
-      });
-
-      const nerdFontPatterns = [
-        /nerd font/i,
-        /symbols only/i,
-        /jetbrains mono.*nerd/i,
-        /fira code.*nerd/i,
-        /hack.*nerd/i,
-        /source code pro.*nerd/i,
-        /ubuntu mono.*nerd/i,
-        /anonymous pro.*nerd/i,
-      ];
-
-      for (const pattern of nerdFontPatterns) {
-        if (pattern.test(stdout)) {
-          // Try to extract font name
-          const match = stdout.match(/([^:\n]*)(?=\s*(nerd|symbols))/i);
-          const fontName = match ? match[1] : 'Nerd Font';
-          return { hasNerdFont: true, font: fontName?.trim() || 'Nerd Font' };
-        }
-      }
-    }
-  } catch {
-    // Font detection failed
-  }
-
-  return { hasNerdFont: false, font: '' };
-}
-
-/**
- * Detect Nerd Font installation in common locations
- */
-async function detectNerdFontInstallation(): Promise<{ hasNerdFont: boolean; font: string }> {
-  try {
-    const { access, readdir } = await import('fs/promises');
-    const { homedir } = await import('os');
-
-    const platform = process.platform;
-    const fontPaths: string[] = [];
-
-    if (platform === 'darwin') {
-      fontPaths.push(
-        `${homedir()}/Library/Fonts`,
-        '/System/Library/Fonts',
-        '/Library/Fonts'
-      );
-    } else if (platform === 'linux') {
-      fontPaths.push(
-        `${homedir()}/.local/share/fonts`,
-        `${homedir()}/.fonts`,
-        '/usr/share/fonts',
-        '/usr/local/share/fonts'
-      );
-    }
-
-    const nerdFontNames = [
-      'jetbrains-mono-nerd-font',
-      'fira-code-nerd-font',
-      'hack-nerd-font',
-      'source-code-pro-nerd-font',
-      'ubuntu-mono-nerd-font',
-      'anonymous-pro-nerd-font',
-    ];
-
-    for (const fontPath of fontPaths) {
-      try {
-        await access(fontPath);
-        const files = await readdir(fontPath);
-
-        for (const file of files) {
-          const fileName = file.toLowerCase();
-          for (const nerdFontName of nerdFontNames) {
-            if (fileName.includes(nerdFontName)) {
-              return { hasNerdFont: true, font: file };
-            }
-          }
-        }
-      } catch {
-        // Can't access this font directory
-      }
-    }
-  } catch {
-    // Font detection failed
-  }
-
-  return { hasNerdFont: false, font: '' };
-}
-
-/**
- * Detect Nerd Font support from environment variables
- */
-function detectFromEnvironment(): { hasNerdFont: boolean } {
-  // Check for various environment variables that might indicate Nerd Font support
-  const nerdFontEnvVars = [
-    'POWERLINE_COMMAND', // Often used with Nerd Fonts
-    'NERDFONTS', // Some terminals set this
-    'FONT_FAMILY', // Some terminals expose the current font
-  ];
-
-  for (const envVar of nerdFontEnvVars) {
-    const value = process.env[envVar];
-    if (value && value.toLowerCase().includes('nerd')) {
-      return { hasNerdFont: true };
-    }
-  }
-
-  // Check if we're in a development environment that likely has Nerd Fonts
-  if (
-    process.env.VSCODE_PID ||
-    process.env.TERM_PROGRAM === 'vscode' ||
-    process.env.TERM_PROGRAM === 'ghostty' ||
-    process.env.TERM_PROGRAM === 'wezterm'
-  ) {
-    return { hasNerdFont: true };
-  }
-
-  return { hasNerdFont: false };
-}
-
-/**
- * Platform-specific Nerd Font detection
- */
-async function detectPlatformSpecific(): Promise<{ hasNerdFont: boolean }> {
-  const platform = process.platform;
-
-  if (platform === 'darwin') {
-    // macOS: check if we're in a common development environment
-    try {
-      const { exec } = await import('child_process');
-      const { promisify } = await import('util');
-      const execAsync = promisify(exec);
-
-      // Check for Homebrew-installed Nerd Fonts
-      const { stdout } = await execAsync('brew list | grep -i font', {
-        timeout: 2000,
-        encoding: 'utf-8',
-      });
-
-      if (stdout.includes('nerd')) {
-        return { hasNerdFont: true };
-      }
-    } catch {
-      // brew command failed or not available
-    }
-  }
-
-  return { hasNerdFont: false };
-}
-
-/**
- * Get environment symbols with version information
- */
-export function getEnvironmentSymbols(symbolSet: SymbolSet): { [key: string]: string } {
+export function getEnvironmentSymbols(symbolSet: SymbolSet): { node: string; python: string; docker: string; git: string; model: string } {
   return {
-    node: '', // Node.js
-    python: '', // Python
-    docker: '', // Docker
+    node: symbolSet.node,
+    python: symbolSet.python,
+    docker: symbolSet.docker,
     git: symbolSet.git,
     model: symbolSet.model,
   };
-}
-
-/**
- * Test if symbols can be displayed properly
- */
-export async function testSymbolDisplay(_symbols: SymbolSet): Promise<boolean> {
-  // In a terminal environment, we can't easily test if symbols display correctly
-  // For now, we'll assume that if we detected Nerd Font support, they can be displayed
-  return true;
 }


### PR DESCRIPTION
## Summary

Phase A of [PRD-003: Rendering Hygiene & Codebase Cleanup](https://github.com/shrwnsan/claude-statusline/blob/prd-003/phase-a/docs/plans/prd-003-rendering-hygiene-and-cleanup.md). Eliminates user-visible glyph artifacts ("random chars") by making Nerd Font opt-in and removing unreliable auto-detection.

### Changes (Tasks A.1 → A.4, sequential)

| Task | What | File(s) |
|---|---|---|
| **A.1** | Add `nerdFont: boolean` config field + `NERD_FONT=1` / `CLAUDE_CODE_STATUSLINE_NERD_FONT=1` env vars | `config.ts` |
| **A.2** | Remove all auto-detection (terminal heuristics, `system_profiler`, `brew list`, font scanning, filesystem walks). Simplify `detectSymbols()` to O(1) config lookup | `symbols.ts` |
| **A.3** | Drop U+FE0E text variation selector from default `contextWindow` symbol — root cause of visible artifacts on Terminal.app/tmux | `config.ts`, `symbols.ts` |
| **A.4** | Fix env-icon ASCII leak: `getEnvironmentSymbols()` now sources from resolved `SymbolSet` (no hardcoded PUA chars). ASCII mode uses `node 22.17 py 3.13 dkr 29.1` | `symbols.ts`, `config.ts`, `context.ts` |

### Breaking change (intentional, documented)

Users who relied on auto-detected Nerd Fonts will now see ASCII. Fix: set `NERD_FONT=1` or `"nerdFont": true` in config. This is documented in the PRD and will be called out in the CHANGELOG (Phase C).

### Validation

- `bun run build` ✅ | `bun run build:bundle` ✅ (49.53 KB, down from 54.83 KB)
- `bun test` (security suite) ✅ — 23/23 pass
- Hexdump confirms zero `FE 0E` (U+FE0E) and zero PUA characters in ASCII mode output
- Functional: default output is ASCII; `NERD_FONT=1` enables Nerd Font glyphs; `noEmoji=1` overrides `nerdFont`

### Out of scope (deferred)

- Phase B (cleanup, dead code, no-exit(1), config walk, VPN hardening, B.4 softWrap unification)
- Phase C (`--self-test`/`--demo`, docs, CHANGELOG)
- PRD-004 (Claude Code 2026 modernization)

Closes tasks A.1–A.4 of #TBD (PRD-003).