### PR TITLE
Phase C: P3 self-test CLI + docs + CHANGELOG (Tasks C.1–C.3)

### DIFF
--- a/.claude-statusline.json.example
+++ b/.claude-statusline.json.example
@@ -54,7 +54,6 @@
   "_forceWidth_note": "Override terminal width detection (for testing/debug only)",
   "forceWidth": null,
 
-  "_softWrap_note": "Legacy soft-wrapping (not needed with truncate: true)",
   "noSoftWrap": false,
   "_noSoftWrap_note": "Disable soft-wrapping completely. Default: false"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.0] - 2026-05-29
+
+### Changed
+- Nerd Font support is now opt-in via `nerdFont: true` config or `NERD_FONT=1`
+  (default: ASCII). Eliminates tofu / random-char rendering on terminals
+  without a Nerd Font installed.
+- Default `contextWindow` symbol no longer includes the U+FE0E text variation
+  selector, fixing visible artifacts on Terminal.app and tmux.
+- Config discovery now walks all parent directories (stops at filesystem root).
+
+### Added
+- `--self-test` and `--demo` CLI flags for verifying rendering without
+  launching Claude Code.
+- `nerdFont` config field and `NERD_FONT` / `CLAUDE_CODE_STATUSLINE_NERD_FONT`
+  environment variables for explicit Nerd Font opt-in.
+
+### Fixed
+- Environment icons (node/python/docker) now respect ASCII mode instead of
+  leaking Nerd Font PUA characters.
+- Non-zero exits replaced with a minimal-mode render to prevent blank
+  statusline (per Claude Code statusline contract).
+
+### Removed
+- Unreliable Nerd Font auto-detection (`system_profiler`, `brew list`,
+  terminal-program heuristics).
+- Vestigial `softWrap` config field and `CLAUDE_CODE_STATUSLINE_SOFT_WRAP`
+  env var (never read). `noSoftWrap` is unaffected and still supported.
+- Dead code: `EnvironmentDetector.formatEnvironmentInfo`,
+  `EnvironmentFormatter.format/Verbose/Minimal`, `softWrapText`,
+  `testSymbolDisplay`, `getAdditionalTools`, indicator-order validation loop.
+
+
 ## [2.3.1] - 2026-02-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ claude-statusline @ main [$!] *Opus ≈76% (ASCII version)
 ```
 
 Shows percentage of context window remaining in the current conversation. The symbol varies by mode:
-- **Nerd Font**: ⚡︎ (lightning bolt)
+- **Nerd Font**: ⚡ (lightning bolt)
 - **ASCII**: ≈ (approximately equals)
 
 **Important Notes:**
@@ -238,7 +238,7 @@ For enhanced visual icons, install Nerd Fonts:
 | **Ahead/Behind** | `⇡⇣` | `A/B` | ASCII when `"noEmoji": true` |
 | **Diverged** | `⇕` | `D` | ASCII when `"noEmoji": true` |
 | **Claude Model** | `🤖` | `*` | ASCII when `"noEmoji": true` |
-| **Context Window** | `⚡︎` | `#` | ASCII when `"noEmoji": true` |
+| **Context Window** | `⚡` | `#` | ASCII when `"noEmoji": true` |
 
 *Note: Examples show ASCII-compatible symbols. Full statusline with Nerd Fonts shows additional symbols: $X!+?>CADAB*
 
@@ -311,9 +311,22 @@ Enhanced security with input validation and type safety:
 - **Runtime**: yaml, zod
 - **Development**: TypeScript, ESLint, Prettier
 
+## Verify Installation
+
+Test your statusline without launching Claude Code:
+
+```bash
+# Quick self-test with default config
+claude-statusline --self-test
+
+# Demo mode: shows 4 rendering variants (ASCII, Nerd Font, narrow, env)
+claude-statusline --demo
+```
+
 ## Troubleshooting
 
 **Common Issues:**
+- **Glyphs render as tofu / random chars**: Run `claude-statusline --demo` to compare variants. If ASCII looks correct but Nerd Font shows boxes, either install a [Nerd Font](https://nerdfonts.com/) or set `NERD_FONT=1` only when using one.
 - **Build failures**: `npm install && npm run build`
 - **Performance issues**: Clear cache `rm -rf /tmp/.claude-statusline-cache/`
 - **Symbol display**: Force ASCII mode with `"noEmoji": true` in config

--- a/docs/guides/guide-001-configuration.md
+++ b/docs/guides/guide-001-configuration.md
@@ -106,7 +106,6 @@ Both configurations work perfectly. The Bun runtime is 5x faster but requires Bu
 |--------|------|---------|-------------|
 | `forceWidth` | number | `null` | Override terminal width detection (testing only) |
 | `noSoftWrap` | boolean | `false` | Disable soft-wrapping completely |
-| `softWrap` | boolean | `false` | Legacy soft-wrapping (not needed with `truncate: true`) |
 
 ### Symbol Customization
 
@@ -115,7 +114,7 @@ Both configurations work perfectly. The Bun runtime is 5x faster but requires Bu
 "symbols": {
   "git": "",        // Git icon
   "model": "󰚩",     // AI model icon
-  "contextWindow": "⚡︎", // Context window usage
+  "contextWindow": "⚡", // Context window usage
   "staged": "+",       // Staged changes
   "conflict": "×",     // Merge conflicts
   "stashed": "⚑",     // Stashed changes
@@ -156,7 +155,6 @@ Both configurations work perfectly. The Bun runtime is 5x faster but requires Bu
   "noGitStatus": false,
   "envContext": true,
   "truncate": true,
-  "softWrap": false,
   "rightMargin": 15,
   "debugWidth": false,
   "symbols": {
@@ -182,7 +180,6 @@ noEmoji: false
 noGitStatus: false
 envContext: true
 truncate: true
-softWrap: false
 rightMargin: 15
 debugWidth: false
 symbols:

--- a/docs/guides/guide-002-troubleshooting.md
+++ b/docs/guides/guide-002-troubleshooting.md
@@ -271,7 +271,7 @@ CLAUDE_CODE_STATUSLINE_TRUNCATE=1 \
 
 **Example**:
 ```
-claude-statusline  main [!] 󰚩glm-4.7 ⚡︎0%                    ct
+claude-statusline  main [!] 󰚩glm-4.7 ⚡0%                    ct
 ```
 
 **Cause**: This is a **known Claude Code TUI rendering bug**, not an issue with the statusline script. Investigation confirmed:
@@ -300,6 +300,27 @@ echo '{"workspace":{"current_dir":"'"$PWD"'"},"model":{"display_name":"Test"}}' 
 2. **Update Claude Code** to the latest version (some TUI bugs have been fixed in newer releases)
 
 **Status**: Known issue in Claude Code's TUI renderer. The statusline script produces correct, clean output. Track the linked GitHub issues for updates.
+
+### Issue: Glyphs Render as Tofu / Random Characters
+
+**Symptoms**: Square boxes (tofu), question marks, or random character fragments instead of icons
+
+**Diagnostic Steps**:
+```bash
+# Run demo mode to compare ASCII vs Nerd Font rendering side-by-side
+claude-statusline --demo
+
+# Test with explicit Nerd Font opt-in
+NERD_FONT=1 claude-statusline --self-test
+
+# Verify no variation selectors in output
+claude-statusline --self-test | hexdump -C | grep 'fe 0e'
+```
+
+**Solutions**:
+1. **Install a Nerd Font**: Download from [nerdfonts.com](https://nerdfonts.com/) and configure your terminal to use it
+2. **Use ASCII mode**: The default is ASCII — if you see tofu, you likely have `NERD_FONT=1` set. Unset it or set `"noEmoji": true` in config
+3. **Check terminal font**: Ensure your terminal emulator is actually using the Nerd Font you installed
 
 ## Debug Mode
 

--- a/docs/plans/prd-003-rendering-hygiene-and-cleanup.md
+++ b/docs/plans/prd-003-rendering-hygiene-and-cleanup.md
@@ -232,9 +232,9 @@ For each phase, before merging:
 
 | Phase | Status | PR | Notes |
 |---|---|---|---|
-| A — P0 rendering fixes | ⬜ Not started | — | — |
-| B — P2 cleanup | ⬜ Not started | — | — |
-| C — P3 self-test | ⬜ Not started | — | — |
+| A — P0 rendering fixes | ✅ Complete | #23 | Merged |
+| B — P2 cleanup | ✅ Complete | #24 | Merged |
+| C — P3 self-test | ✅ Complete | — | This PR |
 
 Update this table as each phase progresses (⬜ → 🔄 → ✅).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ interface ClaudeInput {
  * Main execution function
  */
 export async function main(injected?: ClaudeInput): Promise<void> {
+  // Hoist so catch can still emit a useful minimal fallback if render() throws.
+  let input: ClaudeInput | null = null;
   try {
     // Self-test / demo mode: inject mock input, skip stdin
     const args = process.argv.slice(2);
@@ -57,7 +59,7 @@ export async function main(injected?: ClaudeInput): Promise<void> {
     const config = loadConfig();
 
     // Read input from stdin (or use injected input for testing)
-    const input = injected ?? await readInput();
+    input = injected ?? await readInput();
     if (!input) {
       process.exit(0);
     }
@@ -81,11 +83,11 @@ export async function main(injected?: ClaudeInput): Promise<void> {
       return;
     }
 
-    process.stdout.write(await render(input, fullDir, modelName, contextWindow, config));
+    process.stdout.write(await render(fullDir, modelName, contextWindow, config));
 
   } catch (error) {
     console.error('[ERROR]', error instanceof Error ? error.message : String(error));
-    process.stdout.write(renderMinimal());
+    process.stdout.write(renderMinimal(input));
   }
 }
 
@@ -261,7 +263,6 @@ function wrapModelString(text: string, maxWidth: number): string {
  * Orchestrates git, env, symbol detection and builds the statusline.
  */
 async function render(
-  _input: ClaudeInput,
   fullDir: string,
   modelName: string,
   contextWindow?: ClaudeInput['context_window'],
@@ -327,13 +328,13 @@ async function runSelfTest(demo: boolean): Promise<void> {
   if (demo) {
     for (const preset of presets) {
       const config = { ...loadConfig(), ...preset.configOverrides };
-      const output = await render(mockInput, mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
+      const output = await render(mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
       console.log(`\n── ${preset.label} ──`);
       console.log(output);
     }
   } else {
     const config = loadConfig();
-    const output = await render(mockInput, mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
+    const output = await render(mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
     process.stdout.write(output + '\n');
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,24 +44,21 @@ interface ClaudeInput {
 /**
  * Main execution function
  */
-export async function main(): Promise<void> {
-  let input: ClaudeInput | null = null;
+export async function main(injected?: ClaudeInput): Promise<void> {
   try {
+    // Self-test / demo mode: inject mock input, skip stdin
+    const args = process.argv.slice(2);
+    if (args.includes('--self-test') || args.includes('--demo')) {
+      await runSelfTest(args.includes('--demo'));
+      return;
+    }
+
     // Load configuration
     const config = loadConfig();
 
-    // Initialize components
-    const cache = new Cache(config);
-    const gitOps = new GitOperations(config, cache);
-    const envDetector = new EnvironmentDetector(config, cache);
-
-    // Debug width detection if enabled
-    await debugWidthDetection(config);
-
-    // Read and validate input from stdin
-    input = await readInput();
+    // Read input from stdin (or use injected input for testing)
+    const input = injected ?? await readInput();
     if (!input) {
-      // No input provided - exit silently (graceful degradation)
       process.exit(0);
     }
     if (!validateInput(JSON.stringify(input), config)) {
@@ -70,7 +67,6 @@ export async function main(): Promise<void> {
       return;
     }
 
-    // Extract information from input
     const { fullDir, modelName, contextWindow } = extractInputInfo(input);
     if (!fullDir || !modelName) {
       console.error('[ERROR] Failed to extract required information from input');
@@ -78,7 +74,6 @@ export async function main(): Promise<void> {
       return;
     }
 
-    // Validate directory
     const isValidDir = await validateDirectory(fullDir);
     if (!isValidDir) {
       console.error('[ERROR] Invalid or inaccessible directory:', fullDir);
@@ -86,46 +81,11 @@ export async function main(): Promise<void> {
       return;
     }
 
-    // Get components (run in parallel for better performance)
-    const operations: Promise<any>[] = [
-      gitOps.getGitInfo(fullDir),
-      envDetector.getEnvironmentInfo(),
-      detectSymbols(config),
-    ];
-
-    // Only get terminal width if smart truncation is enabled
-    let terminalWidth: number | undefined;
-    if (config.truncate) {
-      operations.push(getTerminalWidth(config));
-    }
-
-    const results = await Promise.all(operations);
-    const [gitInfo, envInfo, symbols] = results;
-
-    // Extract terminal width from results if it was requested
-    if (config.truncate && results.length > 3) {
-      terminalWidth = results[3];
-    }
-
-    // Build statusline
-    const statusline = await buildStatusline({
-      fullDir,
-      modelName,
-      contextWindow,
-      gitInfo,
-      envInfo,
-      symbols,
-      ...(terminalWidth && { terminalWidth }), // Only include if defined
-      config,
-      gitOps,
-    });
-
-    // Output result
-    process.stdout.write(statusline);
+    process.stdout.write(await render(input, fullDir, modelName, contextWindow, config));
 
   } catch (error) {
     console.error('[ERROR]', error instanceof Error ? error.message : String(error));
-    process.stdout.write(renderMinimal(input));
+    process.stdout.write(renderMinimal());
   }
 }
 
@@ -294,6 +254,88 @@ function applySmartTruncation(params: {
  */
 function wrapModelString(text: string, maxWidth: number): string {
   return getStringDisplayWidth(text) <= maxWidth ? text : `\n${text}`;
+}
+
+/**
+ * Shared render core — no stdout, no process.exit.
+ * Orchestrates git, env, symbol detection and builds the statusline.
+ */
+async function render(
+  _input: ClaudeInput,
+  fullDir: string,
+  modelName: string,
+  contextWindow?: ClaudeInput['context_window'],
+  config?: Config,
+): Promise<string> {
+  config = config ?? loadConfig();
+  const cache = new Cache(config);
+  const gitOps = new GitOperations(config, cache);
+  const envDetector = new EnvironmentDetector(config, cache);
+
+  await debugWidthDetection(config);
+
+  const operations: Promise<any>[] = [
+    gitOps.getGitInfo(fullDir),
+    envDetector.getEnvironmentInfo(),
+    detectSymbols(config),
+  ];
+
+  let terminalWidth: number | undefined;
+  if (config.truncate) {
+    operations.push(getTerminalWidth(config));
+  }
+
+  const results = await Promise.all(operations);
+  const [gitInfo, envInfo, symbols] = results;
+
+  if (config.truncate && results.length > 3) {
+    terminalWidth = results[3];
+  }
+
+  return buildStatusline({
+    fullDir,
+    modelName,
+    contextWindow,
+    gitInfo,
+    envInfo,
+    symbols,
+    ...(terminalWidth && { terminalWidth }),
+    config,
+    gitOps,
+  });
+}
+
+/**
+ * Self-test: render with a canonical mock payload (matching official docs example).
+ * Useful for users debugging their config without launching Claude Code.
+ */
+async function runSelfTest(demo: boolean): Promise<void> {
+  const mockInput = {
+    cwd: process.cwd(),
+    workspace: { current_dir: process.cwd() },
+    model: { display_name: 'Opus' },
+    context_window: { remaining_percentage: 75 },
+  } as unknown as ClaudeInput;
+
+  const presets: { label: string; configOverrides: Partial<Config> }[] = [
+    { label: 'ASCII (default)', configOverrides: { nerdFont: false, noEmoji: false } },
+    { label: 'ASCII + git + env', configOverrides: { nerdFont: false, noEmoji: false, envContext: true } },
+    { label: 'Nerd Font', configOverrides: { nerdFont: true } },
+    { label: 'Narrow terminal (40 cols)', configOverrides: { truncate: true, forceWidth: 40 } },
+  ];
+
+  if (demo) {
+    for (const preset of presets) {
+      const config = { ...loadConfig(), ...preset.configOverrides };
+      const output = await render(mockInput, mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
+      console.log(`\n── ${preset.label} ──`);
+      console.log(output);
+    }
+  } else {
+    const config = loadConfig();
+    const output = await render(mockInput, mockInput.workspace.current_dir, mockInput.model.display_name, mockInput.context_window, config);
+    process.stdout.write(output + '\n');
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase C of [PRD-003: Rendering Hygiene & Codebase Cleanup](https://github.com/shrwnsan/claude-statusline/blob/prd-003/phase-c/docs/plans/prd-003-rendering-hygiene-and-cleanup.md). Adds developer-facing self-test, updates docs, and records the CHANGELOG for the full 2.4.0 release.

### Changes (Tasks C.1 → C.3)

| Task | What | File(s) |
|---|---|---|
| **C.1** | Add `--self-test` / `--demo` CLI flags. Extract shared `render()` core (decision D6). 4 demo presets: ASCII, ASCII+env, Nerd Font, narrow (40 cols). | `src/index.ts` |
| **C.2** | Add "Verify Installation" to README. Add tofu troubleshooting entries. Sweep removed `softWrap` from all docs/examples. Fix residual U+FE0E in docs. | `README.md`, `guide-001`, `guide-002`, `.claude-statusline.json.example` |
| **C.3** | Add `## [2.4.0]` CHANGELOG entry covering all three phases. | `CHANGELOG.md` |

### Usage (new)

```bash
claude-statusline --self-test   # Quick render with default config
claude-statusline --demo         # 4 labeled variants (ASCII, NF, narrow, env)
```

### Validation
- `bun run build` ✅ | `bun run build:bundle` ✅ (44.17 KB)
- `bun test` (security suite) ✅ — 23/23 pass
- `--self-test` produces non-empty output, exit code 0
- `--demo` prints 4 labeled preset variants
- `rg softWrap README.md docs/ .claude-statusline.json.example` — only `noSoftWrap` matches
- Zero U+FE0E in docs

Depends on Phase A (#23) and Phase B (#24), both already merged.

After this PR merges, run Task D.1 (full verification gate) on `main`.