### PR TITLE
docs: update stale references for v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Simple statusline for Claude Code with project-branch, git indicators, and context usage. Optimized for speed with bun. Just the essentials, none of the bloat.
 
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
-![Version](https://img.shields.io/badge/version-2.3.0-green.svg)
+![Version](https://img.shields.io/badge/version-2.4.0-green.svg)
 ![TypeScript](https://img.shields.io/badge/language-TypeScript-3178C6.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D22.6.0-brightgreen.svg)
 ![Bun](https://img.shields.io/badge/runtime-Bun-black.svg)
@@ -213,7 +213,7 @@ Two modes available:
 
 ## Icon Reference & Nerd Font Support
 
-**Nerd Font Support (Optional):** Automatically detects Nerd Fonts and falls back to ASCII equivalents.
+**Nerd Font Support (Optional):** Set `"nerdFont": true` in your config or `NERD_FONT=1` to enable Nerd Font icons. Default is ASCII.
 
 For enhanced visual icons, install Nerd Fonts:
 - **macOS:** `font-jetbrains-mono-nerd-font` via Homebrew

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Claude Statusline Documentation
 
-**Last Updated:** 2026-02-11
-**Version:** 2.0.0
+**Last Updated:** 2026-05-29
+**Version:** 2.4.0
 
 Comprehensive documentation for the Claude Code statusline tool.
 
@@ -67,6 +67,8 @@ Research, evaluations, and project planning.
 | [research-002-competitive-analysis.md](plans/research-002-competitive-analysis.md) | Research | Competitive landscape analysis |
 | [research-003-platform-analysis.md](plans/research-003-platform-analysis.md) | Research | Platform compatibility analysis |
 | [tasks-002-vpn-cross-platform-support.md](plans/tasks-002-vpn-cross-platform-support.md) | Tasks | Implementation tasks for PRD-002 |
+| [prd-003-rendering-hygiene-and-cleanup.md](plans/prd-003-rendering-hygiene-and-cleanup.md) | PRD | Rendering hygiene and codebase cleanup |
+| [tasks-003-prd-003-rendering-hygiene-and-cleanup.md](plans/tasks-003-prd-003-rendering-hygiene-and-cleanup.md) | Tasks | Implementation tasks for PRD-003 |
 
 ---
 

--- a/docs/ref/ARCHITECTURE.md
+++ b/docs/ref/ARCHITECTURE.md
@@ -96,7 +96,7 @@ const ConfigSchema = z.object({
 
 **Purpose**: Git repository status parsing and indicator generation
 
-**Dependencies**: `simple-git` library for cross-platform git operations
+**Dependencies**: Native `git` CLI via `child_process`
 
 **Features**:
 - **Comprehensive status parsing**: staged, unstaged, untracked, conflicts
@@ -115,19 +115,14 @@ if (unstagedChar === 'M') indicators.modified++;
 
 ### Symbol Management (`ui/symbols.ts`)
 
-**Purpose**: Terminal font detection and symbol selection
+**Purpose**: Symbol selection for Nerd Font and ASCII modes
 
 **Features**:
-- **Nerd Font auto-detection** with multiple methods
-- **ASCII fallback** symbol sets
-- **Terminal-specific detection** (VSCode, iTerm, etc.)
-- **Platform-specific font detection**
+- **Explicit opt-in** for Nerd Font via `nerdFont: true` config or `NERD_FONT=1`
+- **ASCII fallback** symbol sets (default when `nerdFont` is unset/false)
+- **Per-symbol overrides** via config file
 
-**Detection Methods**:
-1. **Environment variables**: `NERD_FONT=1`, `TERM_PROGRAM`
-2. **Font list analysis**: `fc-list`, `system_profiler`
-3. **Installation patterns**: Common Nerd Font locations
-4. **Terminal heuristics**: Known Nerd Font-capable terminals
+**Design Decision** (v2.4.0): Auto-detection was removed to prevent tofu/garbled output on terminals without Nerd Fonts. Users opt in explicitly.
 
 ### Width Management (`ui/width.ts`)
 
@@ -136,7 +131,7 @@ if (unstagedChar === 'M') indicators.modified++;
 **Features**:
 - **Multiple width detection methods** with fallbacks
 - **Smart truncation** with branch prioritization
-- **Soft wrapping** support for long content
+- **Model string wrapping** via `noSoftWrap` toggle
 - **Responsive design** for different terminal sizes
 
 **Width Detection Priority**:
@@ -314,7 +309,6 @@ interface StatuslinePlugin {
 
 ### Runtime Dependencies
 
-- **simple-git**: Git operations with cross-platform support
 - **zod**: Runtime type validation and schema definition
 - **yaml**: YAML configuration file support
 

--- a/docs/ref/FEATURE_COMPARISON.md
+++ b/docs/ref/FEATURE_COMPARISON.md
@@ -20,7 +20,7 @@ Comprehensive comparison between Bash v1.0 and TypeScript v2.0 implementations.
 | Git status indicators | ✅ | ✅ | Branch, staged, modified, untracked, etc. |
 | Environment context | ✅ | ✅ | Node.js, Python, Docker versions |
 | Smart truncation | ✅ | ✅ | Prevents statusline overflow |
-| ASCII/Nerd Font detection | ✅ | ✅ | Auto-detects terminal capabilities |
+| ASCII/Nerd Font support | ✅ | ✅ | Opt-in via `nerdFont: true` config |
 | Security validation | ✅ | ✅ | Input validation, path sanitization |
 | Soft-wrapping | ✅ | ✅ | Advanced text wrapping options |
 | **Configuration** |


### PR DESCRIPTION
## Summary

Post-release doc sweep for stale references after PRD-003 (v2.4.0).

| File | Fix |
|---|---|
| `README.md` | Version badge 2.3.0 → 2.4.0; Nerd Font "auto-detects" → "opt-in via nerdFont config" |
| `docs/README.md` | Version 2.0.0 → 2.4.0, date → 2026-05-29, added prd-003 + tasks-003 to plans index |
| `docs/ref/ARCHITECTURE.md` | Removed `simple-git` dep; rewrote symbol management (opt-in, no auto-detect); soft-wrapping → model wrapping |
| `docs/ref/FEATURE_COMPARISON.md` | "Auto-detects terminal capabilities" → "Opt-in via nerdFont: true config" |

No code changes. Build + tests pass.